### PR TITLE
Add nose for better error diagnostics

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,3 +16,4 @@ testtools>=1.4.0 # MIT
 # releasenotes
 reno>=1.8.0 # Apache2
 retry
+nose

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstac
 setenv =
    VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/test-requirements.txt
-commands = python setup.py test --slowest --testr-args='{posargs}'
+commands = nosetests {posargs}
 
 [testenv:pep8]
 commands = flake8 {posargs}


### PR DESCRIPTION
In the main_test unittest won't show exceptions
launched by subprocess (stderr) but nose will
