### PR TITLE
Fix the trailing slash bug

### DIFF
--- a/arsenal/interfaces/api.py
+++ b/arsenal/interfaces/api.py
@@ -39,6 +39,10 @@ class Api(object):
                          view_func=self.get_all_resources,
                          methods=['GET'])
 
+        app.add_url_rule('/v1/resources/',
+                         view_func=self.get_all_resources,
+                         methods=['GET'])
+
         app.add_url_rule('/v1/resources/<uuid>',
                          view_func=self.get_resource,
                          methods=['GET'])

--- a/arsenal/tests/interfaces/test_api.py
+++ b/arsenal/tests/interfaces/test_api.py
@@ -107,7 +107,7 @@ class TestAPI(base.BaseTestCase):
                 Resource(uuid='15', type='server', attributes=dict(ironic_driver='no'))
             ]
 
-            result = http_client.get("{}/resources".format(API_ROOT),
+            result = http_client.get("{}/resources/".format(API_ROOT),
                                      headers=json_content_type)
             self.assertEqual(200, result.status_code)
             self.assertEqual('application/json', result.content_type)


### PR DESCRIPTION
Flask has a way of redirecting to canonial url (/resources) if you
define the url_rule as (/resources/) but it produces a 301, so the
simple solution is to have 2 rules
