### PR TITLE
Skip the execution of the test_main on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+env:
+  - CI='travis'
+
 python:
   - "3.4"
 

--- a/arsenal/interfaces/main.py
+++ b/arsenal/interfaces/main.py
@@ -21,7 +21,7 @@ from ironicclient import client
 
 ironicclient = None
 # TODO(wajdi): Move this in to config loader
-if 'TRAVIS' not in os.environ:
+if 'CI' not in os.environ:
     # TODO(wajdi): Make this a real config
     ironicclient = client.get_client(
         "1",


### PR DESCRIPTION
The TRAVIS env variable does not seems to be
set when running ci builds. The test_main will only
work if connected to a real stack atm.
