### PR TITLE
Bring back test_main

### DIFF
--- a/arsenal/interfaces/main.py
+++ b/arsenal/interfaces/main.py
@@ -18,10 +18,11 @@ from arsenal.drivers.ironic_synchronizer import IronicSynchronizer
 from arsenal.interfaces.api import Api
 from flask import Flask
 from ironicclient import client
+from lazy_object_proxy import Proxy
 
 
-try:
-    ironicclient = client.get_client(
+def make_ironicclient():
+    return client.get_client(
         "1",
         os_username="admin",
         os_password="password",
@@ -29,8 +30,8 @@ try:
         os_auth_url="http://172.27.59.42:5000/v2.0/",
         os_region_name="RegionOne"
     )
-except Exception:
-    ironicclient = None
+
+ironicclient = Proxy(make_ironicclient)
 
 
 def wire_stuff(app):

--- a/arsenal/tests/interfaces/test_main.py
+++ b/arsenal/tests/interfaces/test_main.py
@@ -12,13 +12,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import subprocess
-import unittest
-
-import sys
-
 import os
 import random
+import subprocess
+import sys
+
 import requests
 import requests.exceptions
 from decorator import contextmanager
@@ -26,7 +24,6 @@ from oslotest import base
 from retry.api import retry_call
 
 
-@unittest.skip
 class TestMain(base.BaseTestCase):
 
     def test_application_is_starting(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 pbr>=1.6 # Apache-2.0
 flask
 python-ironicclient
+lazy-object-proxy>=1.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstac
 setenv =
    VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/test-requirements.txt
+passenv = *
 commands = nosetests {posargs}
 
 [testenv:pep8]


### PR DESCRIPTION
Now with a proxied ironicclient so it's not loaded on launch
added full env vars to test env
