### PR TITLE
Introduce the ResourceType concept

### DIFF
--- a/arsenal/core/resource_type.py
+++ b/arsenal/core/resource_type.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+class ResourceType(object):
+    def __init__(self, name):
+        self.name = name
+
+
+class ResourceTypeFactory(object):
+    def __init__(self):
+        self.resource_types = {}
+
+    def register(self, name):
+        if name in self.resource_types:
+            raise ResourceTypeAlreadyExist("Resource type already defined: {}".format(name))
+
+        self.resource_types[name] = ResourceType(name)
+
+    def get(self, name):
+        if name not in self.resource_types:
+            raise UnknownResourceType("Unknown resource type: {}".format(name))
+
+        return self.resource_types[name]
+
+
+class UnknownResourceType(Exception):
+    pass
+
+
+class ResourceTypeAlreadyExist(Exception):
+    pass

--- a/arsenal/tests/core/test_resource_type_factory.py
+++ b/arsenal/tests/core/test_resource_type_factory.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from arsenal.core.resource_type import ResourceTypeFactory, ResourceTypeAlreadyExist, UnknownResourceType
+from oslotest import base
+
+
+class TestResourceTypeFactory(base.BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.factory = ResourceTypeFactory()
+
+    def test_register_and_obtain_a_type(self):
+        self.factory.register("resource_type_name")
+
+        resource_type = self.factory.get("resource_type_name")
+
+        self.assertEqual("resource_type_name", resource_type.name)
+
+    def test_an_unknown_type_raises(self):
+        self.assertRaises(UnknownResourceType, self.factory.get, "unknown_type")
+
+    def test_registering_the_same_resource_type_twice_raises(self):
+        self.factory.register("resource_type_name")
+
+        self.assertRaises(ResourceTypeAlreadyExist, self.factory.register, "resource_type_name")


### PR DESCRIPTION
The "ResourceType" object is meant to replace the "type" field in the resource.
The reason to name it "ResourceType" is that "type" is a reserved word in python
and will lead to annoying situations and variable names down the road on every
level.

The ResourceType object is meant to hold information and capabilities regarding
a given type of resource.  Upcoming attributes will be a list of exporters/synchronizers
and data fields definitions

The ResourceTypeFactory is expected to be initialized at app launch by registering all
the resource types this instance will support, read from a config source.  The protection
against 2 resource types of the same name is to fail early in case a type would appear
twice in a configuration.

This factory could also be populated at run time via API but this is another topic
for another time.
