### PR TITLE
Add a resource type yaml parser

### DIFF
--- a/arsenal/adapters/resource_type_yaml_parser.py
+++ b/arsenal/adapters/resource_type_yaml_parser.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import yaml
+
+
+class ResourceTypeYamlParser(object):
+
+    def __init__(self, resource_type_factory):
+        self.resource_type_factory = resource_type_factory
+
+    def configure_factory_from(self, filename):
+        with open(filename) as f:
+            file_content = f.read()
+            content = yaml.load(file_content)
+
+            for name, specs in content["resource-types"].items():
+                self.resource_type_factory.register(name)

--- a/arsenal/tests/adapters/test_resource_type_yaml_parser.py
+++ b/arsenal/tests/adapters/test_resource_type_yaml_parser.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import tempfile
+import textwrap
+
+from arsenal.adapters.resource_type_yaml_parser import ResourceTypeYamlParser
+from arsenal.core.resource_type import ResourceTypeFactory
+from oslotest import base
+
+
+class TestResourceTypeYamlParser(base.BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = ResourceTypeFactory()
+        self.parser = ResourceTypeYamlParser(self.factory)
+
+    def test_read_some_types(self):
+        with tempfile.NamedTemporaryFile("w") as tempf:
+            with open(tempf.name, 'w') as f:
+                f.write(textwrap.dedent("""
+                    resource-types:
+                        server:
+                        switch:
+                """))
+
+            self.parser.configure_factory_from(tempf.name)
+
+        self.assertEqual("server", self.factory.get("server").name)
+        self.assertEqual("switch", self.factory.get("switch").name)


### PR DESCRIPTION
For first iteration, a yaml parser is proposed, the location to the yaml file defining
the different types will be in the configuration.

This being separated can offer different change opportunities without having
to dig in the config file
