### PR TITLE
Add oslo configuration

### DIFF
--- a/cellar/tests/__init__.py
+++ b/cellar/tests/__init__.py
@@ -1,0 +1,3 @@
+import os
+
+ROOT_DIR = os.path.dirname(__file__)

--- a/cellar/tests/cellar.test.conf
+++ b/cellar/tests/cellar.test.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+
+type_definition_file = types.test.yaml

--- a/cellar/tests/types.test.yaml
+++ b/cellar/tests/types.test.yaml
@@ -1,0 +1,4 @@
+
+resource-types:
+  server:
+  switch:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,10 @@ classifier =
 packages =
     cellar
 
+[entry_points]
+console_scripts =
+    cellar = cellar.interfaces.main:run
+
 [build_sphinx]
 source-dir = doc/source
 build-dir = doc/build


### PR DESCRIPTION
To provide a simple configuration, we use oslo.  To manage the command line
as well as the config file.

More configs to come.

The main test now enforce the program really reads a configuration adn test
that all has been wired properly
