### PR TITLE
Add stevedore to manage datastore adapters

### DIFF
--- a/cellar/tests/cellar.test.conf
+++ b/cellar/tests/cellar.test.conf
@@ -1,3 +1,4 @@
 [DEFAULT]
 
 type_definition_file = types.test.yaml
+datastore = memory

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pbr>=1.6 # Apache-2.0
 flask
 python-ironicclient
 lazy-object-proxy>=1.2.2
+stevedore

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,8 @@ packages =
 [entry_points]
 console_scripts =
     cellar = cellar.interfaces.main:run
+cellar.datastores =
+    memory = cellar.adapters.memory_datastore:MemoryDatastore
 
 [build_sphinx]
 source-dir = doc/source


### PR DESCRIPTION
To simplify the addition of extra drivers, there is now a datastore config
in the DEFAULT scope
