### PR TITLE
Use ResourceType objects instead of strings

### DIFF
--- a/cellar/core/resource.py
+++ b/cellar/core/resource.py
@@ -16,10 +16,10 @@ from cellar import Model
 
 
 class Resource(Model):
-    def __init__(self, uuid=None, type=None, attributes=None,
+    def __init__(self, uuid=None, resource_type=None, attributes=None,
                  foreign_tracking=None, relations=None):
         self.uuid = uuid
-        self.type = type
+        self.resource_type = resource_type
         self.attributes = attributes or {}
         self.foreign_tracking = foreign_tracking or {}
         self.relations = relations or {}

--- a/cellar/core/resource_type.py
+++ b/cellar/core/resource_type.py
@@ -11,12 +11,13 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+from cellar import Model
 from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
 
 
-class ResourceType(object):
+class ResourceType(Model):
     def __init__(self, name):
         self.name = name
 

--- a/cellar/interfaces/api.py
+++ b/cellar/interfaces/api.py
@@ -56,7 +56,7 @@ class Api(object):
         request_data = request.json
 
         resource = self.manager.create_resource(
-            Resource(type=request_data['type'],
+            Resource(resource_type=self.resource_type_factory.get(request_data['type']),
                      attributes=request_data['attributes'],
                      relations=self._to_relations(request_data.get('relations', {}))))
         response = make_response(json.dumps(resource_to_api(resource)), 201)
@@ -137,7 +137,7 @@ def request_to_patch_operation(request):
 
 def resource_to_api(resource):
     return {'uuid': resource.uuid,
-            'type': resource.type,
+            'type': resource.resource_type.name if resource.resource_type else "",
             'attributes': resource.attributes,
             'relations': {k: v.uuid
                           for k, v in resource.relations.items()}}

--- a/cellar/tests/adapters/test_memory_datastore.py
+++ b/cellar/tests/adapters/test_memory_datastore.py
@@ -14,6 +14,7 @@
 from cellar import adapters
 from cellar.adapters.memory_datastore import MemoryDatastore
 from cellar.core.resource import Resource
+from cellar.core.resource_type import ResourceType
 from oslotest import base
 
 
@@ -23,7 +24,7 @@ class TestManager(base.BaseTestCase):
         self.datastore = MemoryDatastore()
 
     def test_save_and_load_a_resource(self):
-        resource = Resource("uuid", type='pdu', attributes={'ironic_driver': 'test'})
+        resource = Resource("uuid", resource_type=ResourceType('pdu'), attributes={'ironic_driver': 'test'})
         self.datastore.save(resource)
 
         self.assertEqual(resource, self.datastore.load("uuid"))

--- a/cellar/tests/core/test_manager.py
+++ b/cellar/tests/core/test_manager.py
@@ -11,11 +11,11 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import mock
 from cellar import adapters
 from cellar.core import manager
 from cellar.core.manager import Manager, InvalidUpdate
 from cellar.core.resource import Resource
-import mock
 from oslotest import base
 
 
@@ -31,10 +31,9 @@ class TestManager(base.BaseTestCase):
     @mock.patch('uuid.uuid4')
     def test_creating_one_resource_returns_it_with_a_uuid_and_saves_it(self, uuid4_mock):
         uuid4_mock.return_value = 'new-uuid'
-        origin_resource = Resource(uuid=None, type='switch', attributes={})
         self.manager.synchronize_resource = mock.Mock()
 
-        created_resource = self.manager.create_resource(origin_resource)
+        created_resource = self.manager.create_resource(Resource())
 
         self.assertEqual('new-uuid', created_resource.uuid)
         self.datastore.save.assert_called_with(created_resource)
@@ -43,8 +42,7 @@ class TestManager(base.BaseTestCase):
     @mock.patch('uuid.uuid4')
     def test_creating_one_resource_with_relations_sync_the_relations(self, uuid4_mock):
         uuid4_mock.return_value = 'new-uuid'
-        origin_resource = Resource(uuid=None, type='switch', attributes={},
-                                   relations={"port 1": Resource("uuid1")})
+        origin_resource = Resource(uuid=None, relations={"port 1": Resource("uuid1")})
 
         self.manager.synchronize_resource = mock.Mock()
 
@@ -57,7 +55,7 @@ class TestManager(base.BaseTestCase):
         ], any_order=True)
 
     def test_fetching_one_resource_returns_it_from_the_datastore(self):
-        resource = Resource(uuid=mock.sentinel.a_uuid, type='firewall', attributes={})
+        resource = Resource(uuid=mock.sentinel.a_uuid)
         self.datastore.load.return_value = resource
 
         loaded_resource = self.manager.get_resource(mock.sentinel.a_uuid)
@@ -71,8 +69,8 @@ class TestManager(base.BaseTestCase):
         self.assertRaises(manager.ResourceNotFound, self.manager.get_resource, 'a uuid')
 
     def test_fetching_all_resources_returns_it_from_the_datastore(self):
-        resourceA = Resource(uuid=mock.sentinel.a_uuid, type='', attributes={})
-        resourceB = Resource(uuid=mock.sentinel.another_uuid, type='', attributes={})
+        resourceA = Resource(uuid=mock.sentinel.a_uuid)
+        resourceB = Resource(uuid=mock.sentinel.another_uuid)
         self.datastore.load_all.return_value = [resourceA, resourceB]
 
         loaded_resources = self.manager.list_resources()


### PR DESCRIPTION
Support for types is provided by the factory that is feeded from
the types file given in the configuration

API has not changed yet and still expose the field as "type"
instead of "resource-type"
